### PR TITLE
Added ability to serve brotli files when using IIS Integration

### DIFF
--- a/src/CompressedStaticFiles/CompressedStaticFileExtensions.cs
+++ b/src/CompressedStaticFiles/CompressedStaticFileExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using System;
+using Microsoft.Extensions.Options;
 
 namespace CompressedStaticFiles
 {
@@ -13,6 +14,17 @@ namespace CompressedStaticFiles
             }
 
             return app.UseMiddleware<CompressedStaticFileMiddleware>();
+        }
+
+
+        public static IApplicationBuilder UseCompressedStaticFiles(this IApplicationBuilder app, StaticFileOptions options)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            return app.UseMiddleware<CompressedStaticFileMiddleware>(Options.Create(options));
         }
     }
 }

--- a/src/CompressedStaticFiles/CompressedStaticFileMiddleware.cs
+++ b/src/CompressedStaticFiles/CompressedStaticFileMiddleware.cs
@@ -46,6 +46,12 @@ namespace CompressedStaticFiles
             _hostingEnv = hostingEnv;
             _logger = loggerFactory.CreateLogger<CompressedStaticFileMiddleware>();
             var contentTypeProvider = staticFileOptions.Value.ContentTypeProvider ?? new FileExtensionContentTypeProvider();
+            var fileExtensionContentTypeProvider = contentTypeProvider as FileExtensionContentTypeProvider;
+            if (fileExtensionContentTypeProvider != null)
+            {
+                fileExtensionContentTypeProvider.Mappings[".br"] = "application/brotli";
+            }
+
             staticFileOptions.Value.ContentTypeProvider = contentTypeProvider;
             staticFileOptions.Value.FileProvider = staticFileOptions.Value.FileProvider ?? hostingEnv.WebRootFileProvider;
             staticFileOptions.Value.OnPrepareResponse = ctx =>

--- a/src/CompressedStaticFiles/project.json
+++ b/src/CompressedStaticFiles/project.json
@@ -1,7 +1,7 @@
 {
   "title": "CompressedStaticFiles",
   "description": "This will ensure that you application will serve gzipped files and brotli compressed files if the browser supports it.",
-  "version": "1.0.1-*",
+  "version": "1.0.2-*",
   "authors": [ "Peter Andersson", "Andrey Kudashkin" ],
   "packOptions": {
     "owners": [ "Peter Andersson" ],


### PR DESCRIPTION
Fix for issue #4 . Register the brotli content type which allows the files to be served.