### PR TITLE
Adding ability to execute OnPrepareResponse that is passed in

### DIFF
--- a/src/CompressedStaticFiles/CompressedStaticFileMiddleware.cs
+++ b/src/CompressedStaticFiles/CompressedStaticFileMiddleware.cs
@@ -54,8 +54,12 @@ namespace CompressedStaticFiles
 
             staticFileOptions.Value.ContentTypeProvider = contentTypeProvider;
             staticFileOptions.Value.FileProvider = staticFileOptions.Value.FileProvider ?? hostingEnv.WebRootFileProvider;
+
+            var originalPrepareResponse = staticFileOptions.Value.OnPrepareResponse;
             staticFileOptions.Value.OnPrepareResponse = ctx =>
             {
+                originalPrepareResponse(ctx);
+                
                 foreach (var compressionType in compressionTypes.Keys)
                 {
                     var fileExtension = compressionTypes[compressionType];


### PR DESCRIPTION
OnPrepareResponse was overwritten so headers of static files couldn't be
manually added to. Caching is the big things affected by this.