### PR TITLE
RequestPath should be taken in to account

### DIFF
--- a/CompressedStaticFiles.Tests/CompressedStaticFileMiddlewareTests.cs
+++ b/CompressedStaticFiles.Tests/CompressedStaticFileMiddlewareTests.cs
@@ -221,5 +221,228 @@ namespace CompressedStaticFiles.Tests
             contentTypeValues.Single().Should().Be("text/html");
         }
     }
+
+    [TestClass]
+    public class CompressedStaticFileMiddlewareShouldRespectRequestPathTests
+    {
+        [TestMethod]
+        public async Task Should_call_next_middleware_if_file_is_not_found()
+        {
+            // Arrange
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCompressedStaticFiles(new StaticFileOptions
+                    {
+                        RequestPath = "/assets"
+                    });
+                    app.Use(next =>
+                    {
+                        return async context =>
+                        {
+                            context.Response.StatusCode = 999;
+                        };
+                    });
+                });
+            var server = new TestServer(builder);
+
+            // Act
+            var response = await server.CreateClient().GetAsync("/assets/this_file_does_not_exist.html");
+
+            // Assert
+            response.StatusCode.Should().Be(999);
+        }
+
+        [TestMethod]
+        public async Task Should_serve_the_uncompressed_file_if_a_compressed_version_does_not_exist()
+        {
+            // Arrange
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCompressedStaticFiles(new StaticFileOptions
+                    {
+                        RequestPath = "/assets"
+                    });
+                    app.Use(next =>
+                    {
+                        return async context =>
+                        {
+                            // this test should never call the next middleware
+                            // set status code to 999 to detect a test failure
+                            context.Response.StatusCode = 999;
+                        };
+                    });
+                }).UseWebRoot(Path.Combine(Environment.CurrentDirectory, "wwwroot"));
+            var server = new TestServer(builder);
+
+            // Act
+            var response = await server.CreateClient().GetAsync("/assets/i_exist_only_uncompressed.html");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            content.Should().Be("uncompressed");
+            response.Content.Headers.TryGetValues("Content-Type", out IEnumerable<string> contentTypeValues);
+            contentTypeValues.Single().Should().Be("text/html");
+        }
+
+        [TestMethod]
+        public async Task Should_serve_the_compressed_file_if_a_compressed_version_exists_and_the_browser_supports_it()
+        {
+            // Arrange
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCompressedStaticFiles(new StaticFileOptions
+                    {
+                        RequestPath = "/assets"
+                    });
+                    app.Use(next =>
+                    {
+                        return async context =>
+                        {
+                            // this test should never call the next middleware
+                            // set status code to 999 to detect a test failure
+                            context.Response.StatusCode = 999;
+                        };
+                    });
+                }).UseWebRoot(Path.Combine(Environment.CurrentDirectory, "wwwroot"));
+            var server = new TestServer(builder);
+
+            // Act
+            var client = server.CreateClient();
+            client.DefaultRequestHeaders.Add("Accept-Encoding", "br, gzip");
+            var response = await client.GetAsync("/assets/i_also_exist_compressed.html");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            content.Should().Be("br");
+            response.Content.Headers.TryGetValues("Content-Type", out IEnumerable<string> contentTypeValues);
+            contentTypeValues.Single().Should().Be("text/html");
+        }
+
+        [TestMethod]
+        public async Task Should_serve_gzip_and_not_br_if_only_gzip_is_accepted_by_the_browser()
+        {
+            // Arrange
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCompressedStaticFiles(new StaticFileOptions
+                    {
+                        RequestPath = "/assets"
+                    });
+                    app.Use(next =>
+                    {
+                        return async context =>
+                        {
+                            // this test should never call the next middleware
+                            // set status code to 999 to detect a test failure
+                            context.Response.StatusCode = 999;
+                        };
+                    });
+                }).UseWebRoot(Path.Combine(Environment.CurrentDirectory, "wwwroot"));
+            var server = new TestServer(builder);
+
+            // Act
+            var client = server.CreateClient();
+            client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip");
+            var response = await client.GetAsync("/assets/i_also_exist_compressed.html");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            content.Should().Be("gzip");
+            response.Content.Headers.TryGetValues("Content-Type", out IEnumerable<string> contentTypeValues);
+            contentTypeValues.Single().Should().Be("text/html");
+        }
+
+        [TestMethod]
+        public async Task Should_serve_the_uncompressed_file_if_it_is_smaller()
+        {
+            // Arrange
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCompressedStaticFiles(new StaticFileOptions
+                    {
+                        RequestPath = "/assets"
+                    });
+                    app.Use(next =>
+                    {
+                        return async context =>
+                        {
+                            // this test should never call the next middleware
+                            // set status code to 999 to detect a test failure
+                            context.Response.StatusCode = 999;
+                        };
+                    });
+                }).UseWebRoot(Path.Combine(Environment.CurrentDirectory, "wwwroot"));
+            var server = new TestServer(builder);
+
+            // Act
+            var client = server.CreateClient();
+            client.DefaultRequestHeaders.Add("Accept-Encoding", "br");
+            var response = await client.GetAsync("/assets/i_am_smaller_in_uncompressed.html");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            content.Should().Be("uncompressed");
+            response.Content.Headers.TryGetValues("Content-Type", out IEnumerable<string> contentTypeValues);
+            contentTypeValues.Single().Should().Be("text/html");
+        }
+
+        [TestMethod]
+        public async Task Should_use_the_file_provider_of_StaticFileOptions_if_it_is_provided()
+        {
+            // Arrange
+            var fileInfo = Substitute.For<IFileInfo>();
+            fileInfo.Exists.Returns(true);
+            fileInfo.IsDirectory.Returns(false);
+            fileInfo.Length.Returns(12);
+            fileInfo.LastModified.Returns(new DateTimeOffset(2018, 12, 16, 13, 36, 0, new TimeSpan()));
+            fileInfo.CreateReadStream().Returns(new MemoryStream(Encoding.UTF8.GetBytes("fileprovider")));
+
+            var mockFileProvider = Substitute.For<IFileProvider>();
+            mockFileProvider.GetFileInfo("/i_only_exist_in_mociFileProvider.html").Returns(fileInfo);
+
+            var staticFileOptions = new StaticFileOptions()
+            {
+                FileProvider = mockFileProvider,
+                RequestPath = "/assets"
+            };
+
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseCompressedStaticFiles(staticFileOptions);
+                    app.Use(next =>
+                    {
+                        return async context =>
+                        {
+                            // this test should never call the next middleware
+                            // set status code to 999 to detect a test failure
+                            context.Response.StatusCode = 999;
+                        };
+                    });
+                }).UseWebRoot(Path.Combine(Environment.CurrentDirectory, "wwwroot"));
+            var server = new TestServer(builder);
+
+            // Act
+            var client = server.CreateClient();
+            client.DefaultRequestHeaders.Add("Accept-Encoding", "br");
+            var response = await client.GetAsync("/assets/i_only_exist_in_mociFileProvider.html");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.StatusCode.Should().Be(200);
+            content.Should().Be("fileprovider");
+            response.Content.Headers.TryGetValues("Content-Type", out IEnumerable<string> contentTypeValues);
+            contentTypeValues.Single().Should().Be("text/html");
+        }
+    }
 }
 

--- a/src/CompressedStaticFiles/CompressedStaticFileMiddleware.cs
+++ b/src/CompressedStaticFiles/CompressedStaticFileMiddleware.cs
@@ -96,7 +96,13 @@ namespace CompressedStaticFiles
         private void ProcessRequest(HttpContext context)
         {
             var fileSystem = _staticFileOptions.Value.FileProvider;
-            var originalFile = fileSystem.GetFileInfo(context.Request.Path);
+
+            if (!context.Request.Path.StartsWithSegments(_staticFileOptions.Value.RequestPath, out var subPath))
+            {
+                return;
+            }
+
+            var originalFile = fileSystem.GetFileInfo(subPath);
 
             if (!originalFile.Exists)
             {
@@ -110,7 +116,7 @@ namespace CompressedStaticFiles
             foreach (var compressionType in supportedEncodings)
             {
                 var fileExtension = compressionTypes[compressionType];
-                var file = fileSystem.GetFileInfo(context.Request.Path + fileExtension);
+                var file = fileSystem.GetFileInfo(subPath + fileExtension);
                 if (file.Exists && file.Length < matchedFile.Length)
                 {
                     matchedFile = file;


### PR DESCRIPTION
## Reference
https://github.com/AnderssonPeter/CompressedStaticFiles/issues/15

## Rationale

If `StaticFileOptions` has `RequestPath` path specified and static files are queried as `{RequestPath}/path-to-a-static-file` then cached versions are not served.

It says that `originalFile` doesn't exist
https://github.com/AnderssonPeter/CompressedStaticFiles/blob/424d6fdf0e0b4259cc02732d67209218b4f1b3a9/src/CompressedStaticFiles/CompressedStaticFileMiddleware.cs#L99-L104